### PR TITLE
Comstar

### DIFF
--- a/Call/CurlCall.php
+++ b/Call/CurlCall.php
@@ -250,7 +250,7 @@ abstract class CurlCall implements ApiCallInterface
                 if (substr($h[0], 0, 1) == "\t")
                     $headers[$key] .= "\r\n\t".trim($h[0]);
                 elseif (!$key)
-                    $headers[0] = trim($h[0]);trim($h[0]);
+                    $headers['Status'] = trim($h[0]);
             }
         }
 

--- a/Call/CurlCall.php
+++ b/Call/CurlCall.php
@@ -18,6 +18,7 @@ abstract class CurlCall implements ApiCallInterface
     protected $responseObject;
     protected $status;
     protected $asAssociativeArray;
+    protected $options;
 
     /**
      * Class constructor
@@ -25,11 +26,13 @@ abstract class CurlCall implements ApiCallInterface
      * @param string $url                API url
      * @param object $requestObject      Request
      * @param bool   $asAssociativeArray Return associative array
+     * @param array  $options            Additional options for the cURL engine
      */
-    public function __construct($url,$requestObject,$asAssociativeArray=false)
+    public function __construct($url,$requestObject,$asAssociativeArray=false,$options = array())
     {
         $this->url = $url;
         $this->requestObject = $requestObject;
+        $this->options = $options;
         $this->asAssociativeArray = $asAssociativeArray;
         $this->generateRequestData();
     }
@@ -180,7 +183,7 @@ abstract class CurlCall implements ApiCallInterface
     public function execute($options, $engine, $freshConnect = false)
     {
         $options['returntransfer']=true;
-        $options = $this->parseCurlOptions($options);
+        $options = $this->parseCurlOptions(array_merge($options, $this->options));
         $this->makeRequest($engine, $options);
         $this->parseResponseData();
         $this->status = $engine->getinfo(CURLINFO_HTTP_CODE);

--- a/Call/CurlCall.php
+++ b/Call/CurlCall.php
@@ -221,6 +221,43 @@ abstract class CurlCall implements ApiCallInterface
     }
 
     /**
+     * Protected method to parse HTTP headers if the exist in the response object
+     *
+     * @param $raw_headers
+     *
+     * @return array
+     *
+     */
+    protected function header_parse($raw_headers)
+    {
+        $headers = array();
+        $key = '';
+
+        foreach(explode("\n", $raw_headers) as $i => $h) {
+            $h = explode(':', $h, 2);
+
+            if (isset($h[1])) {
+                if (!isset($headers[$h[0]]))
+                    $headers[$h[0]] = trim($h[1]);
+                elseif (is_array($headers[$h[0]])) {
+                    $headers[$h[0]] = array_merge($headers[$h[0]], array(trim($h[1])));
+                } else {
+                    $headers[$h[0]] = array_merge(array($headers[$h[0]]), array(trim($h[1])));
+                }
+
+                $key = $h[0];
+            } else {
+                if (substr($h[0], 0, 1) == "\t")
+                    $headers[$key] .= "\r\n\t".trim($h[0]);
+                elseif (!$key)
+                    $headers[0] = trim($h[0]);trim($h[0]);
+            }
+        }
+
+        return $headers;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function generateRequestData()

--- a/Call/HttpDeleteJson.php
+++ b/Call/HttpDeleteJson.php
@@ -34,6 +34,6 @@ class HttpDeleteJson extends CurlCall implements ApiCallInterface
         $curl->setopt(CURLOPT_URL, $this->url.'?'.$this->requestData);
         $curl->setopt(CURLOPT_CUSTOMREQUEST, 'DELETE');
         $curl->setoptArray($options);
-        $this->responseData = $curl->exec();
+        $this->curlExec($curl);
     }
 }

--- a/Call/HttpGetHtml.php
+++ b/Call/HttpGetHtml.php
@@ -22,6 +22,7 @@ class HttpGetHtml extends CurlCall implements ApiCallInterface
         $this->url = $url;
         $this->cookie = $cookie;
         $this->requestObject = $requestObject;
+        $this->generateRequestData();
     }
 
     /**
@@ -30,7 +31,7 @@ class HttpGetHtml extends CurlCall implements ApiCallInterface
     public function generateRequestData()
     {
         if ($this->requestObject) {
-                $this->requestData = http_build_query($this->requestObject);
+                $this->requestData = '?'.http_build_query($this->requestObject);
         }
     }
 

--- a/Call/HttpGetHtml.php
+++ b/Call/HttpGetHtml.php
@@ -54,6 +54,7 @@ class HttpGetHtml extends CurlCall implements ApiCallInterface
         }
         $curl->setopt(CURLOPT_URL, $url);
         $curl->setopt(CURLOPT_COOKIE, $this->cookie);
+        $curl->setopt(CURLOPT_HTTPGET, TRUE);
         $curl->setoptArray($options);
         $this->curlExec($curl);
     }

--- a/Call/HttpGetHtml.php
+++ b/Call/HttpGetHtml.php
@@ -54,7 +54,7 @@ class HttpGetHtml extends CurlCall implements ApiCallInterface
         $curl->setopt(CURLOPT_URL, $url);
         $curl->setopt(CURLOPT_COOKIE, $this->cookie);
         $curl->setoptArray($options);
-        $this->responseData = $curl->exec();
+        $this->curlExec($curl);
     }
 
 }

--- a/Call/HttpGetJson.php
+++ b/Call/HttpGetJson.php
@@ -33,7 +33,7 @@ class HttpGetJson extends CurlCall implements ApiCallInterface
     {
         $curl->setopt(CURLOPT_URL, $this->url.'?'.$this->requestData);
         $curl->setoptArray($options);
-        $this->responseData = $curl->exec();
+        $this->curlExec($curl);
     }
 
 }

--- a/Call/HttpGetXML.php
+++ b/Call/HttpGetXML.php
@@ -1,0 +1,70 @@
+<?php
+namespace Lsw\ApiCallerBundle\Call;
+
+use Lsw\ApiCallerBundle\Helper\Curl;
+
+/**
+ * cURL based API call with request data send as GET parameters
+ *
+ * @author J. Cary Howell <cary.howell@gmail.com>
+ */
+class HttpGetXML extends CurlCall implements ApiCallInterface
+{
+    /**
+     * ApiCall class constructor
+     *
+     * @param string  $url           API url
+     * @param object  $cookie        Cookie
+     * @param object  $requestObject Request
+     * @param boolean $asAssociativeArray
+     */
+    public function __construct($url,$cookie,$asAssociativeArray=false,$requestObject=null)
+    {
+        $this->url = $url;
+        $this->cookie = $cookie;
+        $this->requestObject = $requestObject;
+        $this->asAssociativeArray = $asAssociativeArray;
+        $this->generateRequestData();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function generateRequestData()
+    {
+        if ($this->requestObject) {
+            $this->requestData = '?'.http_build_query($this->requestObject);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function parseResponseData()
+    {
+        if($this->asAssociativeArray) {
+            $xml = simplexml_load_string($this->responseData);
+            $json = json_encode($xml);
+            $this->responseObject = json_decode( $json, TRUE );
+        } else {
+            $this->responseObject = $this->responseData;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function makeRequest($curl, $options)
+    {
+        $url = $this->url;
+        if ($this->requestData) {
+            $url.= $this->requestData;
+        }
+        $curl->setopt(CURLOPT_URL, $url);
+        $curl->setopt(CURLOPT_COOKIE, $this->cookie);
+        $curl->setopt(CURLOPT_HTTPGET, TRUE);
+        $curl->setoptArray($options);
+        $this->curlExec($curl);
+    }
+
+}

--- a/Call/HttpPost.php
+++ b/Call/HttpPost.php
@@ -21,7 +21,15 @@ class HttpPost extends CurlCall implements ApiCallInterface
      */
     public function parseResponseData()
     {
-        $this->responseObject = $this->responseData;
+        if( preg_match("/^HTTP\/\d\.\d/", $this->responseData) ) {
+            $tmp = explode( "\r\n\r\n", $this->responseData);
+            $this->responseObject = array( 'headers' => $this->header_parse($tmp[0]), 'response' => $tmp[1] );
+        } else {
+            if( FALSE == $this->asAssociativeArray )
+                $this->responseObject = json_encode( array( 'headers' => array(), 'response' => $this->responseData ) );
+            else
+                $this->responseObject = array( 'headers' => array(), 'response' => $this->responseData );
+        }
     }
 
     /**

--- a/Call/HttpPost.php
+++ b/Call/HttpPost.php
@@ -21,15 +21,7 @@ class HttpPost extends CurlCall implements ApiCallInterface
      */
     public function parseResponseData()
     {
-        if( preg_match("/^HTTP\/\d\.\d/", $this->responseData) ) {
-            $tmp = explode( "\r\n\r\n", $this->responseData);
-            $this->responseObject = array( 'headers' => $this->header_parse($tmp[0]), 'response' => $tmp[1] );
-        } else {
-            if( FALSE == $this->asAssociativeArray )
-                $this->responseObject = json_encode( array( 'headers' => array(), 'response' => $this->responseData ) );
-            else
-                $this->responseObject = array( 'headers' => array(), 'response' => $this->responseData );
-        }
+        $this->responseObject = $this->responseData;
     }
 
     /**
@@ -41,7 +33,7 @@ class HttpPost extends CurlCall implements ApiCallInterface
         $curl->setopt(CURLOPT_POST, 1);
         $curl->setopt(CURLOPT_POSTFIELDS, $this->requestData);
         $curl->setoptArray($options);
-        $this->responseData = $curl->exec();
+        $this->curlExec($curl);
     }
 
 }

--- a/Call/HttpPostJson.php
+++ b/Call/HttpPostJson.php
@@ -34,7 +34,7 @@ class HttpPostJson extends CurlCall implements ApiCallInterface
         $curl->setopt(CURLOPT_POST, 1);
         $curl->setopt(CURLOPT_POSTFIELDS, $this->requestData);
         $curl->setoptArray($options);
-        $this->responseData = $curl->exec();
+        $this->curlExec($curl);
     }
 
 }

--- a/Call/HttpPutJson.php
+++ b/Call/HttpPutJson.php
@@ -36,7 +36,7 @@ class HttpPutJson extends CurlCall implements ApiCallInterface
         $curl->setopt(CURLOPT_POSTFIELDS, $this->requestData);
         $curl->setopt(CURLOPT_CUSTOMREQUEST, "PUT");
         $curl->setoptArray($options);
-        $this->responseData = $curl->exec();
+        $this->curlExec($curl);
     }
 
 }


### PR DESCRIPTION
Some of the things we modified your bundle to do are:
(a) Added the ability to pass cURL options in the CurlCall constructor
(b) Option to get the headers returned from a cURL call.
(b)(1) Return headers can be stored raw or as an associative array.
(b)(2) New getters getResponseHeaderData and getResponseHeaderObject.
(b)(3) Fixed an issue where a prior cURL POST defaulted to the same method in HttpGetHtml (forced GET).
(c) HttpGetXML - store XML return data in the requestObject as a raw XML or associative array.
(d) Fixed an issue with generateRequestData method was not adding the leading '?'.
(e) Pulled the $curl->exec() function out of each class into CurlCall curlExec() method for parsing headers.