### PR TITLE
Adds a method to set new options or override configured options.

### DIFF
--- a/Caller/ApiCallerInterface.php
+++ b/Caller/ApiCallerInterface.php
@@ -27,4 +27,14 @@ interface ApiCallerInterface
      */
     public function getLastStatus();
 
+    /**
+     * Manually set an option.  Overrides any configured option.
+     *
+     * @param string $name The CURLOPT name
+     * @param string $value The CURLOPT value to set
+     *
+     * @return array
+     */
+    public function setOption($name, $value);
+
 }

--- a/Caller/LoggingApiCaller.php
+++ b/Caller/LoggingApiCaller.php
@@ -82,4 +82,19 @@ class LoggingApiCaller implements ApiCallerInterface
         return $result;
     }
 
+    /**
+     * Manually set an option.  Overrides any configured option.
+     *
+     * @param string $name The CURLOPT name
+     * @param string $value The CURLOPT value to set
+     *
+     * @return array
+     */
+    public function setOption($name, $value)
+    {
+        $this->options[$name] = $value;
+
+        return $this->options;
+    }
+
 }


### PR DESCRIPTION
Some circumstances may require overriding options configured in ```config.yml```.  Options may also need to be set on the fly, such as setting the cookie:
```
    $cookieString = '';
    foreach ($request->cookies->all() as $cookie => $value) {
        $cookieString .= ($cookieString ? '; ' : '') . $cookie . '=' . $value;
    }
    $apiCaller = $this->get('api_caller');
    $apiCaller->setOption('cookie', $cookieString);
```
It's also handy for debugging:
```
    $verbose = fopen('/path/to/myfile.log', 'w+');
    $apiCaller->setOption('verbose', true);
    $apiCaller->setOption('stderr', $verbose);
```