### PR TITLE
Added the possibility to perform GET request using "dirty way"

### DIFF
--- a/Call/CurlCall.php
+++ b/Call/CurlCall.php
@@ -49,6 +49,9 @@ abstract class CurlCall implements ApiCallInterface
     public function setDirtyWay($dirtyWay)
     {
         $this->dirtyWay = $dirtyWay;
+        if($dirtyWay){
+            $this->generateRequestData();
+        }
     }
 
     /**

--- a/Call/CurlCall.php
+++ b/Call/CurlCall.php
@@ -21,6 +21,7 @@ abstract class CurlCall implements ApiCallInterface
     protected $status;
     protected $asAssociativeArray;
     protected $options = array();
+    protected $dirtyWay =  false;
 
     /**
      * Class constructor
@@ -37,6 +38,17 @@ abstract class CurlCall implements ApiCallInterface
         $this->options = $options;
         $this->asAssociativeArray = $asAssociativeArray;
         $this->generateRequestData();
+    }
+
+    /**
+     * Set to perform GET request in dirty way.
+     * If true, then it can perform GET request with url like: foo=x&foo=y&foo=z&status=new&status=on%20hold&s??tatus=open
+     *
+     * @param bool $dirtyWay
+     */
+    public function setDirtyWay($dirtyWay)
+    {
+        $this->dirtyWay = $dirtyWay;
     }
 
     /**

--- a/Call/HttpDeleteJson.php
+++ b/Call/HttpDeleteJson.php
@@ -31,7 +31,11 @@ class HttpDeleteJson extends CurlCall implements ApiCallInterface
      */
     public function makeRequest($curl, $options)
     {
-        $curl->setopt(CURLOPT_URL, $this->url.'?'.$this->requestData);
+        $url = $this->url;
+        if ( $this->requestData ) {
+            $url .= '?' . $this->requestData;
+        }
+        $curl->setopt(CURLOPT_URL, $url);
         $curl->setopt(CURLOPT_CUSTOMREQUEST, 'DELETE');
         $curl->setoptArray($options);
         $this->curlExec($curl);

--- a/Call/HttpGetHtml.php
+++ b/Call/HttpGetHtml.php
@@ -8,8 +8,7 @@ use Lsw\ApiCallerBundle\Helper\Curl;
  *
  * @author Maurits van der Schee <m.vanderschee@leaseweb.com>
  */
-class HttpGetHtml extends CurlCall implements ApiCallInterface
-{
+class HttpGetHtml extends CurlCall implements ApiCallInterface {
     /**
      * ApiCall class constructor
      *
@@ -17,10 +16,9 @@ class HttpGetHtml extends CurlCall implements ApiCallInterface
      * @param object $cookie        Cookie
      * @param object $requestObject Request
      */
-    public function __construct($url,$cookie,$requestObject=null)
-    {
-        $this->url = $url;
-        $this->cookie = $cookie;
+    public function __construct( $url, $cookie, $requestObject = null ) {
+        $this->url           = $url;
+        $this->cookie        = $cookie;
         $this->requestObject = $requestObject;
         $this->generateRequestData();
     }
@@ -28,35 +26,34 @@ class HttpGetHtml extends CurlCall implements ApiCallInterface
     /**
      * {@inheritdoc}
      */
-    public function generateRequestData()
-    {
-        if ($this->requestObject) {
-                $this->requestData = '?'.http_build_query($this->requestObject);
+    public function generateRequestData() {
+        if ( $this->requestObject ) {
+            $this->requestData = http_build_query( $this->requestObject );
+            if ( $this->dirtyWay ) {
+                $this->requestData = preg_replace( '/%5B(?:[0-9]|[1-9][0-9]+)%5D=/', '=', $this->requestData );
+            }
         }
     }
 
     /**
      * {@inheritdoc}
      */
-    public function parseResponseData()
-    {
+    public function parseResponseData() {
         $this->responseObject = $this->responseData;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function makeRequest($curl, $options)
-    {
+    public function makeRequest( $curl, $options ) {
         $url = $this->url;
-        if ($this->requestData) {
-                $url.= $this->requestData;
+        if ( $this->requestData ) {
+            $url .= '?' . $this->requestData;
         }
-        $curl->setopt(CURLOPT_URL, $url);
-        $curl->setopt(CURLOPT_COOKIE, $this->cookie);
-        $curl->setopt(CURLOPT_HTTPGET, TRUE);
-        $curl->setoptArray($options);
-        $this->curlExec($curl);
+        $curl->setopt( CURLOPT_URL, $url );
+        $curl->setopt( CURLOPT_COOKIE, $this->cookie );
+        $curl->setopt( CURLOPT_HTTPGET, true );
+        $curl->setoptArray( $options );
+        $this->curlExec( $curl );
     }
-
 }

--- a/Call/HttpGetJson.php
+++ b/Call/HttpGetJson.php
@@ -15,7 +15,12 @@ class HttpGetJson extends CurlCall implements ApiCallInterface
     */
     public function generateRequestData()
     {
-        $this->requestData = http_build_query($this->requestObject);
+        if ( $this->requestObject ) {
+            $this->requestData = http_build_query( $this->requestObject );
+            if ( $this->dirtyWay ) {
+                $this->requestData = preg_replace( '/%5B(?:[0-9]|[1-9][0-9]+)%5D=/', '=', $this->requestData );
+            }
+        }
     }
 
     /**
@@ -31,7 +36,11 @@ class HttpGetJson extends CurlCall implements ApiCallInterface
      */
     public function makeRequest($curl, $options)
     {
-        $curl->setopt(CURLOPT_URL, $this->url.'?'.$this->requestData);
+        $url = $this->url;
+        if ( $this->requestData ) {
+            $url .= '?' . $this->requestData;
+        }
+        $curl->setopt(CURLOPT_URL, $url);
         $curl->setoptArray($options);
         $this->curlExec($curl);
     }

--- a/Call/HttpGetXML.php
+++ b/Call/HttpGetXML.php
@@ -32,8 +32,11 @@ class HttpGetXML extends CurlCall implements ApiCallInterface
      */
     public function generateRequestData()
     {
-        if ($this->requestObject) {
-            $this->requestData = '?'.http_build_query($this->requestObject);
+        if ( $this->requestObject ) {
+            $this->requestData = http_build_query( $this->requestObject );
+            if ( $this->dirtyWay ) {
+                $this->requestData = preg_replace( '/%5B(?:[0-9]|[1-9][0-9]+)%5D=/', '=', $this->requestData );
+            }
         }
     }
 
@@ -57,8 +60,8 @@ class HttpGetXML extends CurlCall implements ApiCallInterface
     public function makeRequest($curl, $options)
     {
         $url = $this->url;
-        if ($this->requestData) {
-            $url.= $this->requestData;
+        if ( $this->requestData ) {
+            $url .= '?' . $this->requestData;
         }
         $curl->setopt(CURLOPT_URL, $url);
         $curl->setopt(CURLOPT_COOKIE, $this->cookie);

--- a/README.md
+++ b/README.md
@@ -119,6 +119,38 @@ class SomeController extends Controller
 
 ```
 
+### Using the dirty way to perform GET request
+
+If you need to perform GET request to search some information with url like: foo=x&foo=y&foo=z&status=new&status=on%20hold&s??tatus=open
+
+You can use the caller by getting the service "api_caller" and using the "call" function with one of
+the available call types:
+
+- HttpGetHtml
+- HttpGetJson
+- HttpGetXML
+
+Example of usage with the "HttpGetJson" call type:
+
+``` php
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller
+use Lsw\ApiCallerBundle\Call\HttpGetJson;
+
+class SomeController extends Controller
+{
+    public function someAction()
+    {
+        ...
+        $api_caller_request = new HttpGetJson($url, $parameters);
+        $api_caller_request->setDirtyWay(true);
+        $output = $this->get('api_caller')->call($api_caller_request);
+        ...
+    }
+}
+
+```
+
 ## Configuration
 
 By default it uses these cURL options:


### PR DESCRIPTION
Added the possibility to perform GET request to search some information with url like: foo=x&foo=y&foo=z&status=new&status=on%20hold&s‌​tatus=open

You can use the caller by getting the service "api_caller" and using the "call" function with one of
the available call types:

- HttpGetHtml
- HttpGetJson
- HttpGetXML

Example of usage with the "HttpGetJson" call type:

``` php

use Symfony\Bundle\FrameworkBundle\Controller\Controller
use Lsw\ApiCallerBundle\Call\HttpGetJson;

class SomeController extends Controller
{
    public function someAction()
    {
        ...
        $api_caller_request = new HttpGetJson($url, $parameters);
        $api_caller_request->setDirtyWay(true);
        $output = $this->get('api_caller')->call($api_caller_request);
        ...
    }
}

```