### PR TITLE
fix yaml deprecation warnings

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -12,9 +12,9 @@ services:
         class: "%api_call_logger.class%"
         arguments: [ "@logger" ]
         tags:
-            - { name: monolog.logger, channel:api_caller }
+            - { name: monolog.logger, channel: api_caller }
     api_caller.data_collector:
         class: "%api_caller.data_collector.class%"
         arguments: [ "@api_call_logger" ]
         tags:
-            - { name: data_collector, template: "%api_caller.data_collector.template%", id:"api"}
+            - { name: data_collector, template: "%api_caller.data_collector.template%", id: "api"}


### PR DESCRIPTION
Using a colon after an unquoted mapping key that is not followed by an indication character (i.e. " ", ",", "[", "]", "{", "}") is deprecated since version 3.2 and will throw a ParseException in 4.0.