### PR TITLE
Fix PHP 5.3 support

### DIFF
--- a/DataCollector/ApiCallDataCollector.php
+++ b/DataCollector/ApiCallDataCollector.php
@@ -94,10 +94,10 @@ class ApiCallDataCollector extends DataCollector
     }
 
     /**
-    * Support Symfony 3.4
+    * {@inheritdoc}
     */
     public function reset()
     {
-        $this->data = [];
+        $this->data = array();
     }
 }

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It is easy to use from the code and is aimed to have full debugging capabilities
 ## Requirements
 
 * PHP 5.3 with curl support
-* Symfony 2.1
+* Symfony >= 2.1
 
 ## Installation
 


### PR DESCRIPTION
After merging the previous #36 I realized the repository is not longer compatible with PHP5.3. This will have a big impact, especially because I have created a patch version.

Array can only be defined as `[]` from PHP5.4