### PR TITLE
Doctrine\Inflector\Inflector over deprecated class

### DIFF
--- a/Helper/Curl.php
+++ b/Helper/Curl.php
@@ -1,7 +1,7 @@
 <?php
 namespace Lsw\ApiCallerBundle\Helper;
 
-use Doctrine\Common\Util\Inflector;
+use Doctrine\Inflector\Inflector;
 
 /**
  * Class to encapsulate PHP cUrl (curl_xxx) functions for unit tests


### PR DESCRIPTION
This fixes compatibility issues with more recent releases of Doctrine2, where Doctrine\Common\Util\Inflector has been removed.